### PR TITLE
run stack validation/deployment only on active PRs

### DIFF
--- a/.github/workflows/cfn-validate-pr.yml
+++ b/.github/workflows/cfn-validate-pr.yml
@@ -14,8 +14,10 @@ permissions:
   pull-requests: write
   contents: read
 
+# Skip deployment if the PR is closed
 jobs:
   validate-cfn:
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/cloudformation/s3-bucket.yml
+++ b/cloudformation/s3-bucket.yml
@@ -19,7 +19,7 @@ Resources:
         - Key: Environment
           Value: !Ref Environment
         - Key: Environment
-          Value: GithubActions-Cleanup-Validation
+          Value: GithubActions-CFN-Validation-Logic
 
 Outputs:
   BucketName:


### PR DESCRIPTION
CloudFormation stack deployment now runs only when a PR is opened, updated, or reopened. 
The cleanup job runs only when a PR is closed and merged. 
This prevents the stack from being deployed during cleanup and fixes the conflict caused by duplicate stack creation.